### PR TITLE
Remove duplicate return statement in process method

### DIFF
--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -70,8 +70,6 @@ class CsrfMiddleware implements MiddlewareInterface
                 throw new InvalidCsrfException();
             }
             $this->removeToken($params[$this->formKey]);
-
-            return $delegate->process($request);
         }
 
         return $delegate->process($request);


### PR DESCRIPTION
Hi, 

On the process method, line 74, you return the delegate callback, and you return this again 2 lines after (line 76).
You could save 1 line and remove the first return statement on line 74.