### PR TITLE
Utilisation des packages psr, http-interop déprécié

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,10 @@
     "description": "A PSR-15 compatible middleware to prevent CSRF",
     "type": "library",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Grafikart",
-            "email": "contact@grafikart.fr"
-        }
-    ],
+    "authors": [{
+        "name": "Grafikart",
+        "email": "contact@grafikart.fr"
+    }],
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
@@ -17,7 +15,7 @@
     },
     "require": {
         "php": ">=7.1.0",
-        "http-interop/http-middleware": "^0.4.1"
+        "psr/http-server-middleware": "^1.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.2.0",

--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -3,8 +3,8 @@
 namespace Grafikart\Csrf;
 
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class CsrfMiddleware implements MiddlewareInterface

--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -2,10 +2,10 @@
 
 namespace Grafikart\Csrf;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 class CsrfMiddleware implements MiddlewareInterface
 {
@@ -59,7 +59,7 @@ class CsrfMiddleware implements MiddlewareInterface
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate): ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (in_array($request->getMethod(), ['PUT', 'POST', 'DELETE'], true)) {
             $params = $request->getParsedBody() ?: [];
@@ -72,7 +72,7 @@ class CsrfMiddleware implements MiddlewareInterface
             $this->removeToken($params[$this->formKey]);
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 
     /**

--- a/tests/CsrfMiddlewareTest.php
+++ b/tests/CsrfMiddlewareTest.php
@@ -5,7 +5,6 @@ namespace Grafikart\Csrf\Test;
 use Grafikart\Csrf\CsrfMiddleware;
 use Grafikart\Csrf\InvalidCsrfException;
 use Grafikart\Csrf\NoCsrfException;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -29,8 +28,8 @@ class CsrfMiddlewareTest extends TestCase
 
     private function makeDelegate()
     {
-        $delegate = $this->getMockBuilder(DelegateInterface::class)->getMock();
-        $delegate->method('process')->willReturn($this->makeResponse());
+        $delegate = $this->getMockBuilder(\Psr\Http\Server\RequestHandlerInterface::class)->getMock();
+        $delegate->method('handle')->willReturn($this->makeResponse());
 
         return $delegate;
     }
@@ -61,7 +60,7 @@ class CsrfMiddlewareTest extends TestCase
     {
         $middleware = $this->makeMiddleware();
         $delegate = $this->makeDelegate();
-        $delegate->expects($this->once())->method('process');
+        $delegate->expects($this->once())->method('handle');
         $middleware->process(
             $this->makeRequest('GET'),
             $delegate
@@ -72,7 +71,7 @@ class CsrfMiddlewareTest extends TestCase
     {
         $middleware = $this->makeMiddleware();
         $delegate = $this->makeDelegate();
-        $delegate->expects($this->never())->method('process');
+        $delegate->expects($this->never())->method('handle');
         $this->expectException(NoCsrfException::class);
         $middleware->process(
             $this->makeRequest('POST'),
@@ -85,7 +84,7 @@ class CsrfMiddlewareTest extends TestCase
         $middleware = $this->makeMiddleware();
         $token = $middleware->generateToken();
         $delegate = $this->makeDelegate();
-        $delegate->expects($this->once())->method('process')->willReturn($this->makeResponse());
+        $delegate->expects($this->once())->method('handle')->willReturn($this->makeResponse());
         $middleware->process(
             $this->makeRequest('POST', ['_csrf' => $token]),
             $delegate
@@ -97,7 +96,7 @@ class CsrfMiddlewareTest extends TestCase
         $middleware = $this->makeMiddleware();
         $token = $middleware->generateToken();
         $delegate = $this->makeDelegate();
-        $delegate->expects($this->never())->method('process');
+        $delegate->expects($this->never())->method('handle');
         $this->expectException(InvalidCsrfException::class);
         $middleware->process(
             $this->makeRequest('POST', ['_csrf' => 'aze']),
@@ -110,7 +109,7 @@ class CsrfMiddlewareTest extends TestCase
         $middleware = $this->makeMiddleware();
         $token = $middleware->generateToken();
         $delegate = $this->makeDelegate();
-        $delegate->expects($this->once())->method('process')->willReturn($this->makeResponse());
+        $delegate->expects($this->once())->method('handle')->willReturn($this->makeResponse());
         $middleware->process(
             $this->makeRequest('POST', ['_csrf' => $token]),
             $delegate


### PR DESCRIPTION
J'ai vu que les packages de http-interop étaient dépréciés. J'ai donc mis à jour le middleware pour qu'il soit compatible avec les nouvelles version du psr.

Le nouveau package utilisé du coup : [https://packagist.org/packages/psr/http-server-middleware](url)

Il y a très peu de changement (un changement de nom de méthode)